### PR TITLE
Correction of how extract_points_from_channels works. Change to default needle length.

### DIFF
--- a/src/classes/pdf/template_reference.py
+++ b/src/classes/pdf/template_reference.py
@@ -48,7 +48,17 @@ def extract_points_from_channels(channels: list):
     Returns:
         [ [x, y, z], [x, y, z], ...]
     """
-    return [ channel.get_points() for channel in channels]
+    channels_list = []
+    for channel in channels:
+        channel_list = channel.get_points()
+
+        # Append last point at x,y,0 because channel.get_points doesn't include the point at the base for some reason.
+        final_point = channel_list[-1][:]
+        final_point[2] = 0.0
+        channel_list.append(final_point)
+        channels_list.append(channel_list)
+    # channels_list = [ channel.get_points() for channel in channels]
+    return channels_list
 
 
 def get_all_interstitial_lengths(cylinder: BrachyCylinder, needles: list, spacing: float = 0.1) -> list[float]:

--- a/src/classes/pdf/template_reference.py
+++ b/src/classes/pdf/template_reference.py
@@ -52,6 +52,9 @@ def extract_points_from_channels(channels: list):
     for channel in channels:
         channel_list = channel.get_points()
 
+        # Filter out points where the z value is less than 0, error check.
+        filtered_channel_list = [point for point in channel_list if point[2] > 0]
+
         # Append last point at x,y,0 because channel.get_points doesn't include the point at the base for some reason.
         final_point = channel_list[-1][:]
         final_point[2] = 0.0

--- a/src/windows/views/export_view.py
+++ b/src/windows/views/export_view.py
@@ -16,7 +16,7 @@ from windows.views.custom_view import display_action, CustomView
 
 EXPORT_LABEL = "export"
 BASEMAP = "basemap.png"
-DEFAULT_NEEDLE_LENGTH = 160.0
+DEFAULT_NEEDLE_LENGTH = 200
 
 materials = {
     ShapeTypes.CYLINDER: {"rgb": [0.2, 0.55, 0.55], "transparent": True},


### PR DESCRIPTION
The protrusion lengths on the sheet were coming in wrong, because channel.get_points() doesn't return the final point (at the base of the cylinder). I made the change in extract_points_from_channels so as to not affect the channel.get_points() if its used elsewhere. Perhaps a bit patchy, but it also keeps just the points as imported. Could be problematic if the needle points run beyond the cylinder and are not trimmed. It would be better if channel.get_points() returned the actual needle path centerline points, including the lowest point at the base of the cylinder. 

Changed default needle length to a more realistic number. 